### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ path = "../glfw-rs"
 git = "https://github.com/bjz/gl-rs"
 
 
-[[lib]]
+[lib]
 
 name = "blendish"
 path = "src/lib.rs"


### PR DESCRIPTION
The latest cargo builds require that cargo.toml uses [lib] and not [[lib]]. Using [[lib]] outputs an error.
